### PR TITLE
More big and breaking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /wasm_project/pkg
+*.ignore

--- a/server/src/image_manager.rs
+++ b/server/src/image_manager.rs
@@ -24,7 +24,7 @@ pub async fn get_image_list(config: ConfigWrapper, state: StateWrapper, force_re
     let files = flatten(&files);
     for file in files {
         let hash = Sha256::digest(file.clone());
-        let encoded_hash = general_purpose::STANDARD.encode(&hash);
+        let encoded_hash = general_purpose::URL_SAFE_NO_PAD.encode(&hash);
         let short_hash = encoded_hash.chars().take(5).collect();
         images.insert(short_hash, file);
     }
@@ -33,6 +33,12 @@ pub async fn get_image_list(config: ConfigWrapper, state: StateWrapper, force_re
         state.image_hashes.insert(image_hash.clone(), image_path.clone());
     }
     return images;
+}
+
+pub async fn get_hash_by_image_path(image_path: &str, config: ConfigWrapper, state: StateWrapper) -> Option<String> {
+    let image_list: HashMap<String, String> = get_image_list(config, state, false).await;
+    let reversed: HashMap<String, String> = image_list.into_iter().map(|(k,v)|(v,k)).collect();
+    reversed.get(image_path).map_or(None, |v|Some(v.to_owned()))
 }
 
 pub fn flatten(files: &Vec<FileTree>) -> Vec<String> {

--- a/server/src/matrix_server/helpers/image_helper.rs
+++ b/server/src/matrix_server/helpers/image_helper.rs
@@ -1,3 +1,18 @@
-pub(crate) async fn draw_image(x: Option<u8>, y: u8, image: String) -> String {
-    format!("i{:02}{:02}{:=<5}", x.unwrap_or_default(), y, &image)
+use crate::{config_manager::ConfigWrapper, image_manager::get_hash_by_image_path, state_manager::StateWrapper};
+
+pub(crate) async fn draw_image(x: Option<u8>, y: u8, image: String, legacy_mode: bool, config: ConfigWrapper, state: StateWrapper) -> String {
+    if legacy_mode {
+        if image.starts_with("^i") || image.starts_with("^1") || image.starts_with("^2") {
+            return format!("i{:02}{:02}{:=<5}", x.unwrap_or_default(), y, &image);
+        } else {
+            return String::new();
+        }
+    }
+    let img = get_hash_by_image_path(&image, config, state).await;
+    if let Some(img_hash) = img {
+        format!("i{:02}{:02}{:=<5}", x.unwrap_or_default(), y, &img_hash)
+    } else {
+        tracing::warn!("No image matching path ({})", &image);
+        String::new()
+    }
 }

--- a/server/src/matrix_server/server.rs
+++ b/server/src/matrix_server/server.rs
@@ -1,17 +1,16 @@
 use std::{io, net::SocketAddr, time::Duration};
 
 use tokio::{io::{AsyncReadExt, AsyncWriteExt}, net::{TcpListener, TcpStream}, time::sleep};
-use tracing::info;
 
 use crate::{boards::BoardRender, config_manager::ConfigWrapper, state_manager::StateWrapper};
 
 pub async fn run_matrix_server(config: ConfigWrapper, state: StateWrapper) -> io::Result<()> {
-    {
-        let local_config = config.read().await;
-        let board = local_config.get_boards().get("clock").expect("Failed to make board");
-        let cfg = local_config.device_configs.get("default").unwrap();
-        info!("{}", board.render(cfg, config.clone(), state.clone()).await);
-    }
+    // {
+    //     let local_config = config.read().await;
+    //     let board = local_config.get_boards().get("clock").expect("Failed to make board");
+    //     let cfg = local_config.device_configs.get("default").unwrap();
+    //     tracing::info!("{}", board.render(cfg, config.clone(), state.clone()).await);
+    // }
 
     let listener = TcpListener::bind("0.0.0.0:12312").await?;
     loop {

--- a/shared/src/boards.rs
+++ b/shared/src/boards.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BoardDefinition {
-    // referenced_board_variables: Vec<String>,
     pub name: String,
     pub size: (u8, u8),
     pub board_elements: Vec<BoardElement>,
@@ -109,6 +108,18 @@ impl ColourOption {
     pub fn get_options() -> Vec<String> {
         "Default;Specific;Parse Temperature".split(";").map(|x|x.to_string()).collect()
     }
+    pub fn from_str(type_str: &str) -> ColourOption {
+        match type_str {
+            "Default" => ColourOption::Default,
+            "Specific" => ColourOption::Specific(
+                ElementColour::default(),
+            ),
+            "Parse Temperature" => {
+                ColourOption::ParseTemperature
+            }
+            _ => ColourOption::Default,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, PartialOrd, Debug)]
@@ -140,7 +151,7 @@ impl ToString for ElementColour {
 #[derive(Serialize, Deserialize, Clone, PartialEq, PartialOrd, Debug)]
 pub enum BoardElementValue {
     Text(String),
-    Img(String),
+    Img(String, bool /* dynamic */),
 }
 impl Default for BoardElementValue {
     fn default() -> Self {
@@ -152,16 +163,22 @@ impl BoardElementValue {
     pub fn extract_element_value(&self) -> (String, String) {
         match self {
             BoardElementValue::Text(x) => (String::from("Text"), x.clone()),
-            BoardElementValue::Img(x) => (String::from("Image"), x.clone()),
+            BoardElementValue::Img(x, _) => (String::from("Image"), x.clone()),
+        }
+    }
+    pub fn get_type(&self) -> String {
+        match self {
+            BoardElementValue::Text(_) => String::from("Text"),
+            BoardElementValue::Img(_, _) => String::from("Image"),
         }
     }
     pub fn get_types() -> Vec<String> {
-        vec!["Text".to_string(), "Image".to_string()]
+        "Text;Image".split(';').map(|x|x.to_string()).collect()
     }
-    pub fn from_strings(type_string: &str, value: String) -> BoardElementValue {
+    pub fn from_strings(type_string: &str, value: String, dynamic_img: bool) -> BoardElementValue {
         match type_string {
             "Text" => BoardElementValue::Text(value),
-            "Image" => BoardElementValue::Img(value),
+            "Image" => BoardElementValue::Img(value, dynamic_img),
             _ => BoardElementValue::Text(value),
         }
     }

--- a/wasm_project/src/app.rs
+++ b/wasm_project/src/app.rs
@@ -6,7 +6,7 @@ use std::{
 use eframe::egui;
 use shared::{
     board_variables::BoardVariables,
-    boards::{BoardDefinition, BoardElement},
+    boards::BoardDefinition,
     device_config::DeviceConfigs,
 };
 
@@ -39,7 +39,8 @@ pub struct State {
     pub add_board_dialog: AddDialog,
     pub board_name_edit: Option<String>,
     pub rename_board: Option<(String, String)>,
-    pub open_board_elements: HashMap<usize, BoardElement>,
+    pub rename_board_element: Option<String>,
+    pub fonts_sorted: bool,
     //
     pub vars: Arc<Mutex<BoardVariables>>,
     pub current_var: Option<String>,
@@ -52,6 +53,8 @@ pub struct State {
     pub current_device: Option<String>,
     pub add_device_dialog: AddDialog,
     pub devices_has_changed: bool,
+    //
+    pub images: Arc<Mutex<Vec<String>>>,
     //
     pub current_editor: Option<u8>,
 }
@@ -81,6 +84,7 @@ impl MyEguiApp {
         let var_data: Arc<Mutex<BoardVariables>> = Arc::new(Mutex::new(BoardVariables::new()));
         let device_data: Arc<Mutex<DeviceConfigs>> = Arc::new(Mutex::new(DeviceConfigs::new()));
         let font_data: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let image_data: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
 
         // Load Boards from server...
         get("/api/boards", board_data.clone());
@@ -94,12 +98,16 @@ impl MyEguiApp {
         // Load Fonts from server...
         get("/api/fonts", font_data.clone());
 
+        // Load Images from server...
+        get("/api/image_list", image_data.clone());
+
         let setup = MyEguiApp {
             state: Arc::new(Mutex::new(State {
                 boards: board_data,
                 vars: var_data,
                 devices: device_data,
                 fonts: font_data,
+                images: image_data,
                 ..Default::default()
             })),
             ..Default::default()

--- a/wasm_project/src/windows/boards/board_editor.rs
+++ b/wasm_project/src/windows/boards/board_editor.rs
@@ -1,10 +1,11 @@
 use std::sync::{Arc, Mutex};
 
-use egui::{Align2, Color32, Ui};
-use shared::boards::{BoardDefinition, BoardElement, BoardElementValue, ColourOption, ElementColour};
-use wasm_bindgen_futures::spawn_local;
+use egui::{Align2, Ui};
+use shared::boards::BoardDefinition;
 
-use crate::app::State;
+use crate::{app::State, windows::boards::board_element_editor::render_element_editor};
+
+
 
 pub fn render_board_editor(
     ctx: &egui::Context,
@@ -16,7 +17,11 @@ pub fn render_board_editor(
     }
     egui::Window::new("Board Editor")
         .open(board_editor_open)
-        .anchor(Align2::CENTER_TOP, [0., 5.])
+        .anchor(Align2::CENTER_CENTER, [0., 0.])
+        .default_height(ctx.screen_rect().height()*0.75)
+        .max_height(ctx.screen_rect().height()*0.75)
+        .min_width(ctx.screen_rect().width()*0.2)
+        .scroll([true, false])
         .show(ctx, |ui| {
             let current_board = state.lock().unwrap().current_board.clone();
             let boards = state.lock().unwrap().boards.clone();
@@ -29,6 +34,7 @@ pub fn render_board_editor(
             }
             render_board_size_editor(ui, board);
             render_board_elements(ui, board, state.clone());
+            // TODO: Make 'Add Element' button
             //
             render_config_panel(ctx, board);
         });
@@ -100,212 +106,19 @@ fn render_board_size_editor(ui: &mut Ui, board: &mut BoardDefinition) {
 }
 
 fn render_board_elements(ui: &mut Ui, board: &mut BoardDefinition, state: Arc<Mutex<State>>) {
-    let fonts: Vec<String>;
-    {
-        fonts = state.lock().unwrap().fonts.lock().unwrap().clone();
+    for element in &mut board.board_elements {
+        let mut open = None;
+        if let Some(new_name) = &state.lock().unwrap().rename_board_element {
+            if element.name.eq(new_name) {
+                open = Some(true);
+            }
+        }
+        egui::CollapsingHeader::new(&element.name)
+            .open(open)
+            .show(ui, |ui| {
+                render_element_editor(ui, element, open.is_some(), state.clone());
+            });
     }
-    ui.group(|ui| {
-        ui.label("Board Elements");
-        for (idx, element) in board.board_elements.clone().iter().enumerate() {
-            let open_board_elements = &mut state.lock().unwrap().open_board_elements;
-            egui::CollapsingHeader::new(&element.name)
-                // .open(if should_open {Some(true)} else {None})
-                .show(ui, |ui| {
-                    ui.group(|ui| {
-                        ui.label("Name");
-                        let mut element_name = if open_board_elements.contains_key(&idx) {
-                            open_board_elements.get(&idx).unwrap().name.clone()
-                        } else {
-                            element.name.clone()
-                        };
-                        ui.text_edit_singleline(&mut element_name);
-                        if element_name.ne(&element.name) {
-                            if !open_board_elements.contains_key(&idx) {
-                                open_board_elements.insert(idx, element.clone());
-                            }
-                            if element_name.len() > 0 {
-                                open_board_elements.get_mut(&idx).unwrap().name = element_name;
-                            } else {
-                                board.board_elements.get_mut(idx).unwrap().name = String::from("_");
-                            }
-                        }
-                    });
-                    ui.group(|ui| {
-                        ui.label("Position");
-                        ui.horizontal(|ui| {
-                            ui.label("X: ");
-                            {
-                                let mut val = if open_board_elements.contains_key(&idx) {
-                                    element_u8_option_to_string(open_board_elements.get(&idx).unwrap().x)
-                                } else {
-                                    element_u8_option_to_string(element.x)
-                                };
-                                ui.add(
-                                    egui::TextEdit::singleline(&mut val)
-                                        .hint_text("Enter a number"),
-                                );
-                                if val.ne(&element_u8_option_to_string(element.x)) {
-                                    if !open_board_elements.contains_key(&idx) {
-                                        open_board_elements.insert(idx, element.clone());
-                                    }
-                                    if let Ok(value) = val.parse::<u8>() {
-                                        open_board_elements.get_mut(&idx).unwrap().x = Some(value);
-                                    } else if val.is_empty() {
-                                        open_board_elements.get_mut(&idx).unwrap().x = None;
-                                    }
-                                }
-                            }
-                        });
-                        ui.horizontal(|ui| {
-                            ui.label("Y: ");
-                            {
-                                let mut val = if open_board_elements.contains_key(&idx) {
-                                    element_u8_to_string(open_board_elements.get(&idx).unwrap().y)
-                                } else {
-                                    element_u8_to_string(element.y)
-                                };
-                                ui.add(
-                                    egui::TextEdit::singleline(&mut val)
-                                        .hint_text("Enter a number"),
-                                );
-                                if val.ne(&element_u8_to_string(element.y)) {
-                                    if !open_board_elements.contains_key(&idx) {
-                                        open_board_elements.insert(idx, element.clone());
-                                    }
-                                    if let Ok(value) = val.parse::<u8>() {
-                                        open_board_elements.get_mut(&idx).unwrap().y = value;
-                                    } else if val.is_empty() {
-                                        open_board_elements.get_mut(&idx).unwrap().y = 0;
-                                    }
-                                }
-                            }
-                        });
-                    });
-                    ui.horizontal_wrapped(|ui| {
-                        ui.vertical(|ui| {
-                            ui.group(|ui| {
-                                ui.label("Colour");
-                                {
-                                    let mut colour_type = if open_board_elements.contains_key(&idx) {
-                                        open_board_elements.get(&idx).unwrap().colour.get_option()
-                                    } else {
-                                        element.colour.get_option()
-                                    };
-                                    egui::ComboBox::from_id_salt("abc19488-9692-482c-9ab3-2315a6cd1389")
-                                        .selected_text(&colour_type)
-                                        .show_ui(ui, |ui| {
-                                            for opt in ColourOption::get_options() {
-                                                ui.selectable_value(&mut colour_type, opt.clone(), opt.clone());
-                                            }
-                                        });
-                                    if colour_type.ne(&element.colour.get_option()) {
-                                        log::info!("{:#?} -> {:#?}", &colour_type, &element.colour.get_option());
-                                        if !open_board_elements.contains_key(&idx) {
-                                            open_board_elements.insert(idx, element.clone());
-                                        }
-                                        open_board_elements.get_mut(&idx).unwrap().colour = match colour_type.as_str() {
-                                            "Default" => ColourOption::Default,
-                                            "Specific" => ColourOption::Specific(ElementColour::default()),
-                                            "Parse Temperature" => ColourOption::ParseTemperature,
-                                            _ => ColourOption::Default
-                                        };
-                                    }
-                                }
-                                {
-                                    let colour = if open_board_elements.contains_key(&idx) {
-                                        open_board_elements.get(&idx).unwrap().colour.clone()
-                                    } else {
-                                        element.colour.clone()
-                                    };
-                                    if let ColourOption::Specific(colour) = colour {
-                                        let mut colour_edit = colour.to_egui_colour();
-                                        ui.color_edit_button_srgba(&mut colour_edit);
-                                        if colour_edit.ne(&colour.to_egui_colour()) {
-                                            log::info!("{:#?} -> {:#?}", &colour.to_egui_colour(), &colour_edit);
-                                            if !open_board_elements.contains_key(&idx) {
-                                                open_board_elements.insert(idx, element.clone());
-                                            }
-                                            open_board_elements.get_mut(&idx).unwrap().colour = ColourOption::Specific(ElementColour::from_egui_colour(&colour_edit));
-                                            log::info!("{:#?}", open_board_elements);
-                                        }
-                                        ui.label(format!("({}, {}, {}, {})", colour.r, colour.g, colour.b, colour.a));
-                                    }
-                                }
-                            });
-                        });
-                        ui.vertical(|ui| {
-                            ui.group(|ui| {
-                                ui.label("Font");
-                                let mut selected_font = if open_board_elements.contains_key(&idx) {
-                                    open_board_elements.get(&idx).unwrap().font.clone().unwrap_or(String::from("5x8"))
-                                } else {
-                                    element.font.clone().unwrap_or(String::from("5x8"))
-                                };
-                                egui::ComboBox::from_label("")
-                                    .selected_text(&selected_font)
-                                    .show_ui(ui, |ui| {
-                                        for font in &fonts {
-                                            ui.selectable_value(&mut selected_font, font.clone(), font.clone());
-                                        }
-                                    });
-                                if selected_font.ne(&element.font.clone().unwrap_or(String::from("5x8"))) {
-                                    if !open_board_elements.contains_key(&idx) {
-                                        open_board_elements.insert(idx, element.clone());
-                                    }
-                                    open_board_elements.get_mut(&idx).unwrap().font = Some(selected_font);
-                                }
-                            });
-                        });
-                    });
-                    ui.group(|ui| {
-                        let (mut var_type, mut value) = if open_board_elements.contains_key(&idx) {
-                            open_board_elements.get(&idx).unwrap().value.extract_element_value()
-                        } else {
-                            element.value.extract_element_value()
-                        };
-                        ui.horizontal(|ui| {
-                            ui.label("Value");
-                            egui::ComboBox::from_label("")
-                                .selected_text(&var_type)
-                                .show_ui(ui, |ui| {
-                                    for element_type in BoardElementValue::get_types() {
-                                        ui.selectable_value(&mut var_type, element_type.clone(), element_type.clone());
-                                    }
-                                });
-                        });
-                        ui.text_edit_singleline(&mut value);
-                        if var_type.ne(&element.value.extract_element_value().0.clone())
-                            || value.ne(&element.value.extract_element_value().1.clone()) {
-                            if !open_board_elements.contains_key(&idx) {
-                                open_board_elements.insert(idx, element.clone());
-                            }
-                            open_board_elements.get_mut(&idx).unwrap().value = BoardElementValue::from_strings(&var_type, value);
-                        }
-                    });
-                    ui.group(|ui|{
-                        ui.horizontal(|ui| {
-                            if ui.button("Save").clicked() {
-                                if open_board_elements.contains_key(&idx) {
-                                    let f = board.board_elements.get_mut(idx).unwrap();
-                                    f.set(open_board_elements.remove(&idx).unwrap());
-                                    let state2 = state.clone();
-                                    spawn_local(async move {
-                                        state2.lock().unwrap().boards_has_changed = true;
-                                    });
-                                }
-                            }
-                            if ui.button("Cancel").clicked() {
-                                open_board_elements.remove(&idx);
-                            }
-                        });
-                    });
-                });
-        }
-        ui.separator();
-        if ui.button("Add Element").clicked() {
-            board.board_elements.push(BoardElement::default());
-        }
-    });
 }
 
 fn render_config_panel(ctx: &egui::Context, board: &BoardDefinition) {
@@ -314,41 +127,4 @@ fn render_config_panel(ctx: &egui::Context, board: &BoardDefinition) {
         .show(ctx, |ui| {
             ui.label(serde_json::to_string(board).unwrap());
         });
-}
-
-fn element_u8_to_string(val: u8) -> String {
-    if val > 0 {
-        val.to_string()
-    } else {
-        String::new()
-    }
-}
-fn element_u8_option_to_string(val: Option<u8>) -> String {
-    if val.is_some() {
-        val.unwrap().to_string()
-    } else {
-        String::new()
-    }
-}
-
-trait EguiColourCompat {
-    fn to_egui_colour(&self) -> Color32;
-    fn import_egui_colour(&mut self, colour: &Color32);
-    fn from_egui_colour(colour: &Color32) -> ElementColour;
-}
-impl EguiColourCompat for ElementColour {
-    fn to_egui_colour(&self) -> Color32 {
-        Color32::from_rgba_unmultiplied(self.r, self.g, self.b, self.a)
-    }
-    fn import_egui_colour(&mut self, colour: &Color32) {
-        self.r = colour.r();
-        self.g = colour.g();
-        self.b = colour.b();
-        self.a = colour.a();
-    }
-    fn from_egui_colour(colour: &Color32) -> ElementColour {
-        let mut col = ElementColour::default();
-        col.import_egui_colour(colour);
-        col
-    }
 }

--- a/wasm_project/src/windows/boards/board_element_editor.rs
+++ b/wasm_project/src/windows/boards/board_element_editor.rs
@@ -1,0 +1,323 @@
+use std::sync::{Arc, Mutex};
+use egui::{Color32, Ui};
+use shared::boards::{BoardElement, BoardElementValue, ColourOption, ElementColour};
+
+use crate::app::State;
+
+
+pub fn render_element_editor(ui: &mut Ui, board_element: &mut BoardElement, refocus_name: bool, state: Arc<Mutex<State>>) {
+    let value_type = board_element.value.get_type();
+    let mut modified = false;
+    ui.group(|ui| {
+        // TODO: Finish up image element editor
+        // TODO: Add element delete button
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                if render_element_name_editor(ui, board_element, refocus_name, state.clone()) { modified = true; }
+            });
+            ui.separator();
+            ui.vertical(|ui| {
+                if render_element_type_selector(ui, board_element) { modified = true; }
+            });
+        });
+        ui.separator();
+        if render_element_position_editor(ui, board_element) { modified = true; }
+        ui.separator();
+        if value_type.eq("Text") {
+            if render_text_style_editor(ui, board_element, state.clone()) { modified = true; }
+            ui.separator();
+        }
+        if match value_type.as_str() {
+            "Text" => render_text_value_editor(ui, &mut board_element.value),
+            "Image" => render_image_value_editor(ui, &board_element.name, &mut board_element.value, state.clone()),
+            _ => false
+        } { modified = true; }
+    });
+    if modified {
+        state.lock().unwrap().boards_has_changed = true;
+    }
+}
+
+fn render_element_name_editor(ui: &mut Ui, board_element: &mut BoardElement, refocus: bool, state: Arc<Mutex<State>>) -> bool {
+    let mut modified = false;
+    ui.label("Element Name");
+    let text_edit = ui.add(egui::TextEdit::singleline(&mut board_element.name).hint_text("Element Name").desired_width(128.));
+    if refocus {
+        text_edit.request_focus();
+        state.lock().unwrap().rename_board_element = None;
+    }
+    if text_edit.changed() {
+        modified = true;
+        state.lock().unwrap().rename_board_element = Some(board_element.name.clone());
+    }
+    return modified;
+}
+
+fn render_element_type_selector(ui: &mut Ui, board_element: &mut BoardElement) -> bool {
+    let mut modified = false;
+    let mut type_edit = board_element.value.get_type();
+    let mut salt = board_element.name.clone();
+    salt.push_str("66b4210e-a9f1-4def-9099-10e1aa6aea54");
+    ui.label("Element Type");
+    egui::ComboBox::from_id_salt(salt)
+        .selected_text(&type_edit)
+        .show_ui(ui, |ui| {
+            for option in BoardElementValue::get_types() {
+                ui.selectable_value(&mut type_edit, option.clone(), option);
+            }
+        });
+    if type_edit.ne(&board_element.value.get_type()) {
+        board_element.value = BoardElementValue::from_strings(&type_edit, board_element.value.extract_element_value().1, true);
+        modified = true;
+    }
+    modified
+}
+
+fn render_element_position_editor(ui: &mut Ui, board_element: &mut BoardElement) -> bool {
+    let mut modified = false;
+    let mut x_edit = element_u8_option_to_string(board_element.x);
+    let mut y_edit = element_u8_to_string(board_element.y);
+    ui.label("Position");
+    ui.horizontal(|ui| {
+        ui.label("X:");
+        ui.add(egui::TextEdit::singleline(&mut x_edit).hint_text("Centered").desired_width(64.));
+        ui.separator();
+        ui.label("Y:");
+        ui.add(egui::TextEdit::singleline(&mut y_edit).desired_width(64.));
+    });
+    if x_edit.ne(&element_u8_option_to_string(board_element.x)) {
+        let num_string = get_num_from_string(&x_edit);
+        if num_string.is_none() {
+            board_element.x = None;
+        } else {
+            let num_string = num_string.unwrap();
+            if let Ok(x) = num_string.parse::<u8>() {
+                board_element.x = Some(x);
+            }
+        }
+        modified = true;
+    }
+    if y_edit.ne(&element_u8_to_string(board_element.y)) {
+        let num_string = get_num_from_string(&y_edit);
+        if num_string.is_none() {
+            board_element.y = 0;
+        } else {
+            let num_string = num_string.unwrap();
+            if let Ok(y) = num_string.parse::<u8>() {
+                board_element.y = y;
+            }
+        }
+        modified = true;
+    }
+    modified
+}
+
+fn render_text_style_editor(ui: &mut Ui, board_element: &mut BoardElement, state: Arc<Mutex<State>>) -> bool {
+    let mut modified = false;
+    ui.horizontal(|ui| {
+        ui.vertical(|ui| {
+            if render_text_colour_editor(ui, board_element) { modified = true; }
+        });
+        ui.separator();
+        ui.vertical(|ui| {
+            if render_text_font_editor(ui, board_element, state) { modified = true; }
+        });
+    });
+    modified
+}
+
+fn render_text_colour_editor(ui: &mut Ui, board_element: &mut BoardElement) -> bool {
+    let mut modified = false;
+    ui.label("Colour");
+    if render_text_colour_type_selector(ui, board_element) { modified = true; }
+    if board_element.colour.get_option().eq("Specific") {
+        if render_text_colour_select(ui, board_element) { modified = true; }
+    }
+    modified
+}
+
+fn render_text_colour_type_selector(ui: &mut Ui, board_element: &mut BoardElement) -> bool {
+    let mut modified = false;
+    let mut colour_type = board_element.colour.get_option();
+    let mut salt = board_element.name.clone();
+    salt.push_str("abc19488-9692-482c-9ab3-2315a6cd1389");
+    egui::ComboBox::from_id_salt(salt)
+        .selected_text(&colour_type)
+        .show_ui(ui, |ui| {
+            for opt in ColourOption::get_options() {
+                ui.selectable_value(&mut colour_type, opt.clone(), opt.clone());
+            }
+        });
+    if colour_type.ne(&board_element.colour.get_option()) {
+        board_element.colour = ColourOption::from_str(&colour_type);
+        modified = true;
+    }
+    modified
+}
+
+fn render_text_colour_select(ui: &mut Ui, board_element: &mut BoardElement) -> bool {
+    let mut modified = false;
+    let mut change_value = None;
+    if let ColourOption::Specific(colour) = &board_element.colour {
+        let mut colour_edit = colour.to_egui_colour();
+        ui.color_edit_button_srgba(&mut colour_edit);
+        if colour_edit.ne(&colour.to_egui_colour()) {
+            change_value = Some(colour_edit);
+        }
+    }
+    if let Some(value) = change_value {
+        board_element.colour = ColourOption::Specific(ElementColour::from_egui_colour(&value));
+        modified = true;
+    }
+    modified
+}
+
+fn render_text_font_editor(ui: &mut Ui, board_element: &mut BoardElement, state: Arc<Mutex<State>>) -> bool {
+    let mut modified = false;
+    let mut font = board_element.font.clone().unwrap_or(String::from("Default"));
+    ui.label("Font");
+    let mut salt = board_element.name.clone();
+    salt.push_str("4e6bee20-0610-4b8c-9a72-10f8297144d0");
+    egui::ComboBox::from_id_salt(salt)
+        .selected_text(&font)
+        .show_ui(ui, |ui| {
+            ui.selectable_value(&mut font, "Default".to_string(), "Default".to_string());
+            let mut state = state.lock().unwrap();
+            {
+                if !state.fonts_sorted {
+                    state.fonts.lock().unwrap().sort();
+                    state.fonts_sorted = true;
+                }
+            }
+            let fonts = state.fonts.lock().unwrap().clone();
+            for opt in fonts {
+                ui.selectable_value(&mut font, opt.clone(), opt.clone());
+            }
+        });
+    if font.ne(&board_element.font.clone().unwrap_or(String::from("Default"))) {
+        board_element.font = if font.eq("Default") { None } else { Some(font) };
+        modified = true;
+    }
+    modified
+}
+
+fn render_text_value_editor(ui: &mut Ui, value: &mut BoardElementValue) -> bool {
+    let mut modified = false;
+    ui.label("Text Editor");
+    if let BoardElementValue::Text(value) = value {
+        let old_val = value.clone();
+        ui.text_edit_singleline(value);
+        if old_val.ne(value) {
+            modified = true;
+        }
+    }
+    modified
+}
+
+fn render_image_value_editor(ui: &mut Ui, board_name: &str, value: &mut BoardElementValue, state: Arc<Mutex<State>>) -> bool {
+    let mut modified = false;
+    ui.label("Image Editor");
+    if let BoardElementValue::Img(value, dynamic) = value {
+        let old_dynamic = *dynamic;
+        ui.checkbox(dynamic, "Dynamic");
+        if *dynamic != old_dynamic {
+            modified = true;
+        }
+        //
+        let mut salt = board_name.to_string();
+        salt.push_str("2a59c793-8f64-44c8-a140-b40df0a0fcf4");
+        ui.indent(salt, |ui| {
+            if *dynamic {
+                if render_image_value_editor_dynamic(ui, value) { modified = true; }
+            } else {
+                if render_image_value_editor_static(ui, board_name, value, state) { modified = true; }
+            }
+        });
+    }
+    modified
+}
+
+fn render_image_value_editor_static(ui: &mut Ui, board_name: &str, value: &mut String, state: Arc<Mutex<State>>) -> bool {
+    let mut modified = false;
+    let mut value_edit = value.clone();
+    let mut salt = board_name.to_string();
+    salt.push_str("25d5238e-9cc1-4b13-a495-28f4aa9d30d5");
+    ui.label("Static Image Editor");
+    egui::ComboBox::from_id_salt(salt)
+        .selected_text(&value_edit)
+        .show_ui(ui, |ui| {
+            let state = state.lock().unwrap();
+            let images = state.images.lock().unwrap();
+            if !images.contains(&value_edit) {
+                ui.selectable_value(&mut value_edit, value.clone(), value.clone());
+            }
+            for image in &*images {
+                ui.selectable_value(&mut value_edit, image.clone(), image.clone());
+            }
+        });
+    if value_edit.ne(value) {
+        *value = value_edit;
+        modified = true;
+    }
+    modified
+}
+
+fn render_image_value_editor_dynamic(ui: &mut Ui, value: &mut String) -> bool {
+    let mut modified = false;
+    let old_val = value.clone();
+    ui.label("Dynamic Image Editor");
+    ui.text_edit_singleline(value);
+    if old_val.ne(value) {
+        modified = true;
+    }
+    modified
+}
+
+
+
+// Utility Functions
+fn element_u8_to_string(val: u8) -> String {
+    if val > 0 {
+        val.to_string()
+    } else {
+        String::from("0")
+    }
+}
+fn element_u8_option_to_string(val: Option<u8>) -> String {
+    if val.is_some() {
+        val.unwrap().to_string()
+    } else {
+        String::new()
+    }
+}
+fn get_num_from_string(input: &str) -> Option<String> {
+    let re = regex::Regex::new(r"(?P<number>\d+)").unwrap();
+    let vals = re.captures(input);
+    if vals.is_none() {
+        return None;
+    }
+    let vals = vals.unwrap();
+    Some(vals["number"].to_owned())
+}
+
+trait EguiColourCompat {
+    fn to_egui_colour(&self) -> Color32;
+    fn import_egui_colour(&mut self, colour: &Color32);
+    fn from_egui_colour(colour: &Color32) -> ElementColour;
+}
+impl EguiColourCompat for ElementColour {
+    fn to_egui_colour(&self) -> Color32 {
+        Color32::from_rgba_unmultiplied(self.r, self.g, self.b, self.a)
+    }
+    fn import_egui_colour(&mut self, colour: &Color32) {
+        self.r = colour.r();
+        self.g = colour.g();
+        self.b = colour.b();
+        self.a = colour.a();
+    }
+    fn from_egui_colour(colour: &Color32) -> ElementColour {
+        let mut col = ElementColour::default();
+        col.import_egui_colour(colour);
+        col
+    }
+}

--- a/wasm_project/src/windows/boards/mod.rs
+++ b/wasm_project/src/windows/boards/mod.rs
@@ -1,3 +1,4 @@
 pub mod board_editor;
 pub mod board_list;
 pub mod board_add;
+pub mod board_element_editor;

--- a/wasm_project/src/windows/devices/device_editor.rs
+++ b/wasm_project/src/windows/devices/device_editor.rs
@@ -17,7 +17,11 @@ pub fn render_device_editor(
     }
     egui::Window::new("Device Editor")
         .open(device_editor_open)
-        .anchor(Align2::CENTER_TOP, [0., 5.])
+        .anchor(Align2::CENTER_CENTER, [0., 0.])
+        .default_height(ctx.screen_rect().height()*0.75)
+        .max_height(ctx.screen_rect().height()*0.75)
+        .min_width(ctx.screen_rect().width()*0.2)
+        .scroll([true, false])
         .show(ctx, |ui| {
             let current_device = state.lock().unwrap().current_device.clone();
             let devices = state.lock().unwrap().devices.clone();
@@ -33,6 +37,7 @@ pub fn render_device_editor(
             render_temperature_colours_editor(ui, &device_ip, &mut devices, state.clone());
             render_brightness_editor(ui, &device_ip, &mut devices, state.clone());
             render_board_list_editor(ui, &device_ip, &mut devices, state.clone());
+            ui.label(format!("{:#?}", ctx.screen_rect()));
             //
             render_config_panel(ctx, &devices.get(&device_ip).unwrap());
         });

--- a/wasm_project/src/windows/vars/var_editor.rs
+++ b/wasm_project/src/windows/vars/var_editor.rs
@@ -15,7 +15,11 @@ pub fn render_var_editor(
     }
     egui::Window::new("Variable Editor")
     .open(vars_editor_open)
-    .anchor(Align2::CENTER_TOP, [0., 5.])
+    .anchor(Align2::CENTER_CENTER, [0., 0.])
+    .default_height(ctx.screen_rect().height()*0.75)
+    .max_height(ctx.screen_rect().height()*0.75)
+    .min_width(ctx.screen_rect().width()*0.2)
+    .scroll([true, false])
     .show(ctx, |ui| {
         let current_var = state.lock().unwrap().current_var.clone();
         let vars = state.lock().unwrap().vars.clone();


### PR DESCRIPTION
Added:
- Some functionality for legacy mode
- Getting an image hash by path
- Web server get full current config '/config.json'
- Web server get list of images without hash
- Distinction between dynamic and static images
- Board element editor lets you select an image from the existing ones in the static image editor
- Re-wrote the entire board editor for better ease of use
- Changed some formatting for all of the editors

Removed:
- Rendering the clock board on boot